### PR TITLE
Fix: #60 , prevent scroll-to-top button from blinking on scroll 

### DIFF
--- a/components/BackToTopButton.jsx
+++ b/components/BackToTopButton.jsx
@@ -10,17 +10,20 @@ export default function BackToTopButton() {
   useEffect(() => {
     const toggleVisibility = () => {
       if (window.scrollY > 200) {
-        setIsVisible(true);
-        setAnimate(true); // trigger bounce animation
-        setTimeout(() => setAnimate(false), 600); // remove after animation finishes
+        // only trigger animation when changing from hidden → visible
+        if (!isVisible) {
+          setIsVisible(true);
+          setAnimate(true);
+          setTimeout(() => setAnimate(false), 600);
+        }
       } else {
-        setIsVisible(false);
+        if (isVisible) setIsVisible(false);
       }
     };
 
     window.addEventListener("scroll", toggleVisibility);
     return () => window.removeEventListener("scroll", toggleVisibility);
-  }, []);
+  }, [isVisible]); // add isVisible as dependency
 
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: "smooth" });
@@ -29,16 +32,15 @@ export default function BackToTopButton() {
   return (
     <div className="fixed bottom-6 right-6">
       <button
-      onClick={scrollToTop}
-      aria-label="Back to top"
-      className={`relative flex items-center justify-center w-14 h-14 rounded-full 
-      bg-gradient-to-r from-red-600 to-orange-500 text-white shadow-lg 
-      transition-all duration-300 hover:scale-110 hover:shadow-xl group
-      ${isVisible ? "opacity-100" : "opacity-0"}
-      ${animate ? "animate-bounceIn" : ""}
-      ${isVisible && !animate ? "animate-wiggle" : ""}`}
-    >
-      <ChevronUp size={28} strokeWidth={3} />
+        onClick={scrollToTop}
+        aria-label="Back to top"
+        className={`relative flex items-center justify-center w-14 h-14 rounded-full 
+        bg-gradient-to-r from-red-600 to-orange-500 text-white shadow-lg 
+        transition-all duration-300 hover:scale-110 hover:shadow-xl group
+        ${isVisible ? "opacity-100" : "opacity-0"}
+        ${animate ? "animate-bounceIn" : ""}`}
+      >
+        <ChevronUp size={28} strokeWidth={3} />
 
         {/* Tooltip */}
         <span
@@ -48,7 +50,6 @@ export default function BackToTopButton() {
           transition-all duration-300 ease-out shadow-md"
         >
           Back to top
-          {/* Rounded arrow */}
           <span
             className="absolute left-1/2 -translate-x-1/2 top-full w-3 h-3 
             bg-gradient-to-r from-red-500 to-orange-400 rotate-45 rounded-sm"


### PR DESCRIPTION
This PR fixes the issue where the scroll-to-top button was blinking/flickering while scrolling.

Added a visibility check so that the bounce animation only plays when the button first appears, not on every scroll event.

Removed unnecessary re-triggering of animations to ensure smoother behavior.

The button now fades and animates smoothly without visual glitches.

Fixes: #60 

https://github.com/user-attachments/assets/2c5b727a-cf54-4b2b-9cb1-6c8ae90b8348

 

---
## EntelligenceAI PR Summary 
 This PR fixes and optimizes the BackToTopButton component's animation behavior and performance.
- Added isVisible to useEffect dependency array to properly react to visibility state changes
- Improved conditional logic to only update state when necessary
- Removed unnecessary wiggle animation
- Enhanced code formatting and removed redundant tooltip comment 

